### PR TITLE
[WIP] Replace ::slate with ::node spec

### DIFF
--- a/src/util/slate_hiccup.cljs
+++ b/src/util/slate_hiccup.cljs
@@ -15,6 +15,17 @@
               :ordered-list :unordered-list :list-item
               :code-block})
 
+(s/def ::text (s/or :string string? :number number?))
+(s/def ::type (s/or :text ::text
+                    :mark marks
+                    :inline inlines
+                    :block blocks
+                    :document #{:document}))
+(s/def ::attr (s/map-of keyword? any? :gen-max 1))
+(s/def ::node (s/spec (s/cat :type ::type
+                             :attrs (s/? ::attr)
+                             :nodes (s/* ::node))))
+
 (defn node [types]
   (s/cat :type (s/and keyword? #(types %))
          :attrs (s/? map?)


### PR DESCRIPTION
Refactor ::slate to leverage spec more, specifically encoding the structure of a
node in a spec itself rather than a function that returns a regex spec.
Currently a WIP because I did not replace where ::slate is used (`make-ast`) as
the ::node spec returns a different conform value than ::slate --- the ::node
spec is more granular with its labeling (i.e. gives a more verbose path) but
it's structure is not a drop-in replacement for ::slate.

Eventually ::node should replace the node function and the ::slate spec.